### PR TITLE
Suppress "reflectiveCalls" feature warnings

### DIFF
--- a/lab1/build.sbt
+++ b/lab1/build.sbt
@@ -1,5 +1,10 @@
 scalaVersion := "2.11.12"
 
+// Suppress "there were X feature warnings; re-run with -feature for details".
+// These appear because chisel use a language feature that's not available in
+// all scala implementations.
+scalacOptions += "-language:reflectiveCalls"
+
 resolvers ++= Seq(
   Resolver.sonatypeRepo("snapshots"),
   Resolver.sonatypeRepo("releases")

--- a/lab2/build.sbt
+++ b/lab2/build.sbt
@@ -1,5 +1,10 @@
 scalaVersion := "2.11.12"
 
+// Suppress "there were X feature warnings; re-run with -feature for details".
+// These appear because chisel use a language feature that's not available in
+// all scala implementations.
+scalacOptions += "-language:reflectiveCalls"
+
 resolvers ++= Seq(
   Resolver.sonatypeRepo("snapshots"),
   Resolver.sonatypeRepo("releases")

--- a/lab4/build.sbt
+++ b/lab4/build.sbt
@@ -1,5 +1,10 @@
 scalaVersion := "2.11.12"
 
+// Suppress "there were X feature warnings; re-run with -feature for details".
+// These appear because chisel use a language feature that's not available in
+// all scala implementations.
+scalacOptions += "-language:reflectiveCalls"
+
 resolvers ++= Seq(
   Resolver.sonatypeRepo("snapshots"),
   Resolver.sonatypeRepo("releases")

--- a/lab5/build.sbt
+++ b/lab5/build.sbt
@@ -1,5 +1,10 @@
 scalaVersion := "2.11.12"
 
+// Suppress "there were X feature warnings; re-run with -feature for details".
+// These appear because chisel use a language feature that's not available in
+// all scala implementations.
+scalacOptions += "-language:reflectiveCalls"
+
 resolvers ++= Seq(
   Resolver.sonatypeRepo("snapshots"),
   Resolver.sonatypeRepo("releases")

--- a/lab6/build.sbt
+++ b/lab6/build.sbt
@@ -1,5 +1,10 @@
 scalaVersion := "2.11.12"
 
+// Suppress "there were X feature warnings; re-run with -feature for details".
+// These appear because chisel use a language feature that's not available in
+// all scala implementations.
+scalacOptions += "-language:reflectiveCalls"
+
 resolvers ++= Seq(
   Resolver.sonatypeRepo("snapshots"),
   Resolver.sonatypeRepo("releases")

--- a/lab8/build.sbt
+++ b/lab8/build.sbt
@@ -1,5 +1,10 @@
 scalaVersion := "2.11.12"
 
+// Suppress "there were X feature warnings; re-run with -feature for details".
+// These appear because chisel use a language feature that's not available in
+// all scala implementations.
+scalacOptions += "-language:reflectiveCalls"
+
 resolvers ++= Seq(
   Resolver.sonatypeRepo("snapshots"),
   Resolver.sonatypeRepo("releases")

--- a/labx/build.sbt
+++ b/labx/build.sbt
@@ -1,5 +1,10 @@
 scalaVersion := "2.11.12"
 
+// Suppress "there were X feature warnings; re-run with -feature for details".
+// These appear because chisel use a language feature that's not available in
+// all scala implementations.
+scalacOptions += "-language:reflectiveCalls"
+
 resolvers ++= Seq(
   Resolver.sonatypeRepo("snapshots"),
   Resolver.sonatypeRepo("releases")

--- a/vending/build.sbt
+++ b/vending/build.sbt
@@ -1,5 +1,10 @@
 scalaVersion := "2.11.12"
 
+// Suppress "there were X feature warnings; re-run with -feature for details".
+// These appear because chisel use a language feature that's not available in
+// all scala implementations.
+scalacOptions += "-language:reflectiveCalls"
+
 resolvers ++= Seq(
   Resolver.sonatypeRepo("snapshots"),
   Resolver.sonatypeRepo("releases")


### PR DESCRIPTION
The warnings appear whenever you access an `io` field, since Chisel uses a language feature that's not available in all Scala implementations.

This disables those warnings by explicitly telling the compiler that we need this language feature!

This makes it easier for inexperienced users / people just learning chisel, that they don't see the redundant `there were X feature warnings; re-run with -feature for details` warnings when they compile their code.