### PR TITLE
Specifying the width (7.W) of the wire in lab6

### DIFF
--- a/lab6/src/main/scala/SevenSegDecoder.scala
+++ b/lab6/src/main/scala/SevenSegDecoder.scala
@@ -8,7 +8,7 @@ class SevenSegDecoder extends Module {
     val an = Output(UInt(4.W))
   })
 
-  val sevSeg = WireInit(0.U)
+  val sevSeg = WireInit(0.U(7.W))
 
   // ***** your code starts here *****
 


### PR DESCRIPTION
This solves some issues when specifying the display characters in binary