### PR TITLE
The arguments in BufferedTx are flipped

### DIFF
--- a/lab7/README.md
+++ b/lab7/README.md
@@ -39,11 +39,10 @@ The UART component is a Chisel module. You can instantiate it with the
 following code:
 
 ```scala   
-val uart = Module(new BufferedTx(115200, 100000000))
+val uart = Module(new BufferedTx(100000000, 115200))
 ```
 
-The first parameter is the baud rate, the second parameter is the clock
-frequency. The ```BufferedTx``` component has a read/valid interface to
+The first parameter is the clock frequency, the second parameter is the baud rate. The ```BufferedTx``` component has a read/valid interface to
 send characters to the UART.
 
 To see the output of the UART you need to connect it to a terminal program.


### PR DESCRIPTION
The baud rate and the frequency are supposed to be flipped as seen here:

```scala   
class BufferedTx(frequency: Int, baudRate: Int) extends Module {
  val io = IO(new Bundle {
    val txd = Output(UInt(1.W))
    val channel = Flipped(new UartIO())
  })
  val tx = Module(new Tx(frequency, baudRate))
  val buf = Module(new Buffer())

  buf.io.in <> io.channel
  tx.io.channel <> buf.io.out
  io.txd <> tx.io.txd
}
```
