### PR TITLE
Fix typo: occured -> occurred in FAQ.md

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -54,7 +54,7 @@ Exception in thread "main" ...
 Caused by: (THE REAL ERROR MESSAGE)
     (more indented messages)
 ```
-In the second section of indented messages, you may see links highlighted in blue. These will take you to the portions of your code where the error has occured.
+In the second section of indented messages, you may see links highlighted in blue. These will take you to the portions of your code where the error has occurred.
 
 ### IndexOutOfBoundsException
 Might occur when you're trying to do a sub-field assignment (see above) on a vector. 


### PR DESCRIPTION
## Summary

Fix a minor typo in FAQ.md:

- **Before:** `the error has occured`
- **After:** `the error has occurred`

## Changes

- FAQ.md line 57: corrected `occured` → `occurred`

## Testing

N/A (documentation only)

## Related Issue

Fixes #15