### PR TITLE
Fix typos in FAQ

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -44,7 +44,7 @@ io.y(1) := 1.U
 ```
 To get around this, use *extraction and concatenation*, see the following [SO post](https://stackoverflow.com/questions/40950073/chisel-3-assignment-to-bit-range).
 
-Alternatively, unpack your bus into a vector of booleans, modify it, and then repack it as a bus again, see the following entry from [the Chisel Cookbook](https://github.com/freechipsproject/chisel3/wiki/Cookbook#how-do-i-do-subword-assignment-assign-to-some-bits-in-a-uint) ("How do I do subword assignement?")
+Alternatively, unpack your bus into a vector of booleans, modify it, and then repack it as a bus again, see the following entry from [the Chisel Cookbook](https://github.com/freechipsproject/chisel3/wiki/Cookbook#how-do-i-do-subword-assignment-assign-to-some-bits-in-a-uint) ("How do I do subword assignment?")
 
 ### Understanding very long stack traces
 You may sometimes meet a very long stack trace when you've made an error. This occurs when the error is not Chisel-specific but it is a Scala error. When you meet the long stack traces, most error msgs will be indented. Scroll up from the bottom, until you meet an unindented message
@@ -54,7 +54,7 @@ Exception in thread "main" ...
 Caused by: (THE REAL ERROR MESSAGE)
     (more indented messages)
 ```
-In the second section of indented messages, you may see links highlighted in blue. These will take you to the portions of your code where the error has occured.
+In the second section of indented messages, you may see links highlighted in blue. These will take you to the portions of your code where the error has occurred.
 
 ### IndexOutOfBoundsException
 Might occur when you're trying to do a sub-field assignment (see above) on a vector. 


### PR DESCRIPTION
Fixes two small typos in the FAQ documentation:

- "assignement" -> "assignment"
- "occured" -> "occurred"